### PR TITLE
Patch 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This work is licensed under a
 [cc-by-nc-sa-shield]: https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg
 
 # Garry's Mod: Trolleybus System
-## Version: Beta 1.0
+## Version: Beta 1.1
 
 Trolleybus Simulator addon for Garry's Mod.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Addon's API allows developers create their own trolleybuses and other elements, 
 Developers:
 * [Shadow Bonnie (RUS)](https://steamcommunity.com/id/shadowbonnierus) (Igor Platunov. Main coder, initiator of idea about trolleybuses in Garry's Mod)
 * [Ivano](https://steamcommunity.com/profiles/76561198221032424) (Ivan Opilat. Content maker, designer)
-* [Jorek](https://steamcommunity.com/id/overlord__) (Georgy Novikov. Map and content maker)
+* [Joorek](https://steamcommunity.com/id/overlord__) (Georgy Novikov. Map and content maker)
 * [Mavid](https://steamcommunity.com/profiles/76561198999620249) (David Mutolapov. Content maker, designer, provides information about real world details)
 * [Aleksei2506](https://steamcommunity.com/id/Aleksei2506) (Aleksey Dovgal. Content maker, provides information about real world details)
 

--- a/lua/entities/trolleybus_ent_aksm321/shared.lua
+++ b/lua/entities/trolleybus_ent_aksm321/shared.lua
@@ -1032,33 +1032,6 @@ Trolleybus_System.BuildDialGauge(ENT,"cylinderpressure2","","prib",12.68,6.08,0,
 	return -air*11
 end,"models/trolleybus/aksm321/manometerarrow.mdl",nil,Vector(0,0,-1))
 
-/*Trolleybus_System.BuildMultiScreen(ENT,"screen","screen",0,0,400,300,3/400,function(self,data,x,y,w,h,hovered,cx,cy)
-	local utils = Trolleybus_System.MultiScreenUtils
-
-	surface.SetDrawColor(0,255,255)
-	surface.DrawRect(x,y,w,h)
-	
-	if hovered and utils.InBounds2(0,0,200,200,cx,cy) then
-		surface.SetDrawColor(255,0,0)
-	else
-		surface.SetDrawColor(255,255,0)
-	end
-	
-	surface.DrawRect(x,y,200,200)
-end,function(self,data,x,y,w,h)
-	local utils = Trolleybus_System.MultiScreenUtils
-
-	if utils.InBounds2(0,0,200,200,x,y) then
-		return "TestBox"
-	end
-end,function(self,data,ply,x,y,w,h)
-	local utils = Trolleybus_System.MultiScreenUtils
-
-	if utils.InBounds2(0,0,200,200,x,y) then
-		return print("TestBoxActivated")
-	end
-end,think,think_sv)*/
-
 Trolleybus_System.BuildMovingMirror(ENT,"left_mirror",Vector(208.61,49.67,13.67),Angle(0,-90,0),10,10,"models/trolleybus/aksm321/mirror_left.mdl",Vector(225.03,51.41,21.39),Angle(0,0,0),"Bone003","Bone004",Vector(-2,1.5,-0.3),Angle(-1,-179,-1),6.7,15,false,true,-45,45,-45,45,-10,10,-10,10,nil,10,3,0,-5)
 Trolleybus_System.BuildMovingMirror(ENT,"middle_mirror",Vector(225.52,17.97,24.87),Angle(0,-180,0),10,10,"models/trolleybus/aksm321/mirror_middle.mdl",Vector(220.13,0.15,32.88),Angle(0,0,0),"Bone001","Bone002",Vector(-1.8,0,0.3),Angle(0,-180,0),11.5,6,true,false,-35,35,-35,35,-20,10,-20,10,nil,-20,-0,-15)
 Trolleybus_System.BuildMovingMirror(ENT,"right_mirror",Vector(225,-26,7),Angle(0,-180,0),10,10,"models/trolleybus/aksm321/mirror_right.mdl",Vector(224.31,-51.86,24.72),Angle(0,0,0),"Bone001","Bone002",Vector(-2.2,-1,-0.7),Angle(2,168,-1),6.7,15,false,true,-45,45,-45,45,-10,10,-10,10,nil,-22,8,0,-2)

--- a/lua/entities/trolleybus_ent_aksm321n/shared.lua
+++ b/lua/entities/trolleybus_ent_aksm321n/shared.lua
@@ -942,33 +942,6 @@ Trolleybus_System.BuildDialGauge(ENT,"akbvoltage","trolleybus.aksm321n.dialgauge
 	return voltage<12 and -voltage*1.5 or voltage<14 and -18-(voltage-12)*22 or -18-44-(voltage-14)*10
 end,"models/trolleybus/aksm321n/manometerarrow.mdl",nil,Vector(0.2,0.23,-0.58))
 
-/*Trolleybus_System.BuildMultiScreen(ENT,"screen","screen",0,0,400,300,3/400,function(self,data,x,y,w,h,hovered,cx,cy)
-	local utils = Trolleybus_System.MultiScreenUtils
-
-	surface.SetDrawColor(0,255,255)
-	surface.DrawRect(x,y,w,h)
-	
-	if hovered and utils.InBounds2(0,0,200,200,cx,cy) then
-		surface.SetDrawColor(255,0,0)
-	else
-		surface.SetDrawColor(255,255,0)
-	end
-	
-	surface.DrawRect(x,y,200,200)
-end,function(self,data,x,y,w,h)
-	local utils = Trolleybus_System.MultiScreenUtils
-
-	if utils.InBounds2(0,0,200,200,x,y) then
-		return "TestBox"
-	end
-end,function(self,data,ply,x,y,w,h)
-	local utils = Trolleybus_System.MultiScreenUtils
-
-	if utils.InBounds2(0,0,200,200,x,y) then
-		return print("TestBoxActivated")
-	end
-end,think,think_sv)*/
-
 Trolleybus_System.BuildMovingMirror(ENT,"left_mirror",Vector(208.61,49.67,8.67),Angle(0,-90,0),10,10,"models/trolleybus/aksm321n/mirror_left.mdl",Vector(225.09,51.52,16.89),Angle(0,0,0),"Bone001","Bone002",Vector(-2,1.4,-0.3),Angle(-1,-178,-1),6.7,15,false,true,-45,45,-45,45,-10,10,-10,10,nil,10,3,0,-5)
 Trolleybus_System.BuildMovingMirror(ENT,"middle_mirror",Vector(225.52,17.97,19.87),Angle(0,-180,0),10,10,"models/trolleybus/aksm321n/mirror_middle.mdl",Vector(220.07,0.23,28.26),Angle(0,0,0),"Bone001","Bone002",Vector(-1.72,0,0.3),Angle(0,-180,0),11.5,7,true,false,-35,35,-35,35,-20,10,-20,10,nil,-20,-0,-15)
 Trolleybus_System.BuildMovingMirror(ENT,"right_mirror",Vector(225,-26,2),Angle(0,-180,0),10,10,"models/trolleybus/aksm321n/mirror_right.mdl",Vector(224.35,-51.94,19.7),Angle(0,0,0),"Bone001","Bone002",Vector(-2,-1.4,-0.7),Angle(2,179,-1),6.7,15,false,true,-45,45,-45,45,-10,10,-10,10,nil,-22,-2,0,-2)

--- a/lua/trolleybus_system/cl_contactnetwork.lua
+++ b/lua/trolleybus_system/cl_contactnetwork.lua
@@ -37,9 +37,13 @@ Trolleybus_System.ReceiveMassiveData("ContactNetwork",function(data)
 	if data.Connections then
 		for k,v in pairs(data.Connections) do
 			local obj = Trolleybus_System.ContactNetwork.GetObject(k)
+			if !obj then continue end
 
 			for k2,v2 in pairs(v) do
-				obj:ConnectConnectableTo(k2,Trolleybus_System.ContactNetwork.GetObject(v2[1]),v2[2])
+				local obj2 = Trolleybus_System.ContactNetwork.GetObject(v2[1])
+				if !obj2 then continue end
+
+				obj:ConnectConnectableTo(k2,obj2,v2[2])
 			end
 		end
 

--- a/lua/trolleybus_system/contactnetwork.lua
+++ b/lua/trolleybus_system/contactnetwork.lua
@@ -523,6 +523,7 @@ Trolleybus_System.ContactNetwork.Types = {
 				Vector(37.53,10.08),Vector(37.53,-9.14),
 				Vector(56.10,6.86),Vector(122.87,-9.35),
 				Vector(46.82,11.02),Vector(46.82,9.17),Vector(46.81,-8.23),Vector(46.82,-10.06),
+				Vector(37.9,11.62),Vector(37.9,8.45),Vector(37.9,-7.63),Vector(37.9,-10.77),
 			},
 			langs = {
 				Angle(0,0,0),Angle(0,0,0),Angle(0,13.24,0),Angle(0,8.24,0),Angle(0,-13.94,0),Angle(0,-10.75,0),
@@ -532,7 +533,7 @@ Trolleybus_System.ContactNetwork.Types = {
 				Vector(89.73,2.21,1.43),Vector(89.73,-5.01,1.43)
 			},
 			lnwires = {
-				{{9,10},{11,12,true},nil,nil,6,7,nil,nil,3,4,5,8},
+				{{9,10},{11,12,true},nil,nil,6,7,nil,nil,3,5,4,8},
 				{nil,nil,9,11,10,5,6,12,{1,nil},{nil,1},{2,nil,true},{nil,2,true}},
 			},
 			ConnectablePositions = {
@@ -595,10 +596,10 @@ Trolleybus_System.ContactNetwork.Types = {
 				{Start = function(self,data) return self.ldata[9],true end,End = function(self,data) return self.ldata[10],true end},
 				{Start = function(self,data) return self.ldata[10],true end,End = 5},
 				{Start = function(self,data) return self.ldata[14],true end,End = 6},
-				{Start = function(self,data) return self.ldata[7],true end,End = function(self,data) return self.ldata[11],true end},
-				{Start = function(self,data) return self.ldata[7],true end,End = function(self,data) return self.ldata[12],true end},
-				{Start = function(self,data) return self.ldata[8],true end,End = function(self,data) return self.ldata[13],true end},
-				{Start = function(self,data) return self.ldata[8],true end,End = function(self,data) return self.ldata[14],true end},
+				{Start = function(self,data) return self.ldata[data.NW.GetVar("LeftDir") and 7 or 15],true end,End = function(self,data) return self.ldata[11],true end},
+				{Start = function(self,data) return self.ldata[data.NW.GetVar("LeftDir") and 16 or 7],true end,End = function(self,data) return self.ldata[12],true end},
+				{Start = function(self,data) return self.ldata[data.NW.GetVar("RightDir") and 8 or 17],true end,End = function(self,data) return self.ldata[13],true end},
+				{Start = function(self,data) return self.ldata[data.NW.GetVar("RightDir") and 18 or 8],true end,End = function(self,data) return self.ldata[14],true end},
 			},
 			Initialize = function(self,data,pos,ang)
 				data.Pos = pos

--- a/lua/trolleybus_system/contactnetwork.lua
+++ b/lua/trolleybus_system/contactnetwork.lua
@@ -136,23 +136,6 @@ local function ChangeMainPosByChangingLocalPosLocal(mpos,mang,lpos,lang,npos,nan
 	return ChangeMainPosByChangingLocalPos(mpos,mang,opos,oang,npos,nang)
 end
 
-local loop
-local function LoopSavedCalcWheelData(cwire,self,data,polepos,polelen,endpos,nwire,simplepos)
-	local lop = loop
-	if !lop then loop = {} end
-
-	loop[cwire] = true
-
-	local dt
-	if !loop[nwire] then
-		dt = self:CalculateWheelData(data,polepos,polelen,endpos,nwire,simplepos)
-	end
-
-	if !lop then loop = nil end
-
-	return dt
-end
-
 local function PlayContactSound(bus,pos,snd)
 	local speed = math.abs(bus:GetMoveSpeed())
 	
@@ -208,6 +191,9 @@ Trolleybus_System.ContactNetwork.Types = {
 					end,
 				},
 			},
+			Wires = {
+				{Start = 1,End = 2},
+			},
 			Initialize = function(self,data,pos,ang)
 				data.Start = {pos,ang}
 				data.End = {pos+ang:Forward()*10,ang}
@@ -256,9 +242,8 @@ Trolleybus_System.ContactNetwork.Types = {
 			GetAngles = function(self,data)
 				return (data.End[1]-data.Start[1]):Angle()
 			end,
-			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,simplepos)
-				local startp,endp = data.Start,data.End
-				local errend,pos,ang = WheelPosOnLine(startp[1],endp[1],polepos,polelen,endpos)
+			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,start,endp,simplepos)
+				local errend,pos,ang = WheelPosOnLine(start,endp,polepos,polelen,endpos)
 
 				if simplepos then
 					return pos and {pos = pos,ang = ang} or nil
@@ -268,15 +253,6 @@ Trolleybus_System.ContactNetwork.Types = {
 					
 					return {error = 1,wire = wire,endpos = errend}
 				end
-			end,
-			GetWiresCount = function(self)
-				return 1
-			end,
-			GetWireByConnectable = function(self,connectable)
-				return 1,connectable==2
-			end,
-			GetConnectableByWire = function(self,wire,endpos)
-				return endpos and 2 or 1
 			end,
 			GetWiresToUpdateVoltage = function(self,connectable)
 				return {1}
@@ -341,6 +317,9 @@ Trolleybus_System.ContactNetwork.Types = {
 				},
 			},
 			Properties = {},
+			Wires = {
+				{Start = 1,End = 2},
+			},
 			Initialize = function(self,data,pos,ang)
 				data.Start = pos
 				data.End = pos+ang:Forward()*20
@@ -411,15 +390,6 @@ Trolleybus_System.ContactNetwork.Types = {
 			GetAngles = function(self,data)
 				return (data.End-data.Start):Angle()
 			end,
-			GetWiresCount = function(self)
-				return 1
-			end,
-			GetWireByConnectable = function(self,connectable)
-				return 1,connectable==2
-			end,
-			GetConnectableByWire = function(self,wire,endpos)
-				return endpos and 2 or 1
-			end,
 			GetWiresToUpdateVoltage = function(self,connectable)
 				return {1}
 			end,
@@ -461,6 +431,7 @@ Trolleybus_System.ContactNetwork.Types = {
 					end,
 				},
 			},
+			Wires = {},
 			Initialize = function(self,data,pos,ang)
 				data.Pos = pos
 				data.Ang = ang
@@ -540,8 +511,6 @@ Trolleybus_System.ContactNetwork.Types = {
 			end,
 			GetPosition = function(self,data) return data.Pos end,
 			GetAngles = function(self,data) return data.Ang end,
-			GetWiresCount = function(self) return 1 end,
-			GetWireByConnectable = function(self,connectable) return 1,connectable==2 end,
 			GetVoltage = function(self,data)
 				return data.NW.GetVar("Disabled") and 0 or Trolleybus_System.ContactNetwork.GetVoltage()*(data.Power or 1)
 			end,
@@ -561,6 +530,10 @@ Trolleybus_System.ContactNetwork.Types = {
 			lsusp = {
 				Vector(35.12,14.05,1.66),Vector(35.10,-13.16,1.66),Vector(50.64,15.54,1.66),Vector(50.63,-14.65,1.66),
 				Vector(89.73,2.21,1.43),Vector(89.73,-5.01,1.43)
+			},
+			lnwires = {
+				{{9,10},{11,12,true},nil,nil,6,7,nil,nil,3,4,5,8},
+				{nil,nil,9,11,10,5,6,12,{1,nil},{nil,1},{2,nil,true},{nil,2,true}},
 			},
 			ConnectablePositions = {
 				{
@@ -613,6 +586,20 @@ Trolleybus_System.ContactNetwork.Types = {
 				},
 			},
 			Properties = {},
+			Wires = {
+				{Start = 1,End = function(self,data) return self.ldata[7],true end},
+				{Start = 2,End = function(self,data) return self.ldata[8],true end},
+				{Start = function(self,data) return self.ldata[11],true end,End = 3},
+				{Start = function(self,data) return self.ldata[13],true end,End = 4},
+				{Start = function(self,data) return self.ldata[12],true end,End = function(self,data) return self.ldata[9],true end},
+				{Start = function(self,data) return self.ldata[9],true end,End = function(self,data) return self.ldata[10],true end},
+				{Start = function(self,data) return self.ldata[10],true end,End = 5},
+				{Start = function(self,data) return self.ldata[14],true end,End = 6},
+				{Start = function(self,data) return self.ldata[7],true end,End = function(self,data) return self.ldata[11],true end},
+				{Start = function(self,data) return self.ldata[7],true end,End = function(self,data) return self.ldata[12],true end},
+				{Start = function(self,data) return self.ldata[8],true end,End = function(self,data) return self.ldata[13],true end},
+				{Start = function(self,data) return self.ldata[8],true end,End = function(self,data) return self.ldata[14],true end},
+			},
 			Initialize = function(self,data,pos,ang)
 				data.Pos = pos
 				data.Ang = ang
@@ -653,13 +640,7 @@ Trolleybus_System.ContactNetwork.Types = {
 			GetPosition = function(self,data) return data.Pos end,
 			Rotate = function(self,data,ang) data.Ang = ang end,
 			GetAngles = function(self,data) return data.Ang end,
-			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,simplepos)
-				local start = self.ldata[wire==1 and 1 or wire==2 and 2 or wire==3 and 11 or wire==4 and 13 or wire==5 and 12 or wire==6 and 9 or wire==7 and 10 or wire==8 and 14 or (wire==9 or wire==10) and 7 or (wire==11 or wire==12) and 8]
-				local endp = self.ldata[wire==1 and 7 or wire==2 and 8 or wire==3 and 3 or wire==4 and 4 or wire==5 and 9 or wire==6 and 10 or wire==7 and 5 or wire==8 and 6 or wire==9 and 11 or wire==10 and 12 or wire==11 and 13 or wire==12 and 14]
-
-				start = LocalToWorld(start,angle_zero,data.Pos,data.Ang)
-				endp = LocalToWorld(endp,angle_zero,data.Pos,data.Ang)
-
+			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,start,endp,simplepos)
 				local errend,pos,ang = WheelPosOnLine(start,endp,polepos,polelen,endpos)
 
 				if simplepos then
@@ -667,41 +648,21 @@ Trolleybus_System.ContactNetwork.Types = {
 				else
 					if pos then return {pos = pos,ang = ang,wire = wire} end
 					if errend==nil then return end
-					
-					local ldir = data.NW.GetVar("LeftDir",false)
-					local rdir = data.NW.GetVar("RightDir",false)
 
-					local nwire = errend and
-						(wire==1 and (ldir and 9 or 10) or wire==2 and (rdir and 11 or 12) or wire==5 and 6 or wire==6 and 7 or wire==9 and 3 or wire==10 and 5 or wire==11 and 4 or wire==12 and 8)
-						or !errend and
-						(wire==(ldir and 9 or 10) and 1 or wire==(rdir and 11 or 12) and 2 or wire==6 and 5 or wire==7 and 6 or wire==3 and 9 or wire==4 and 11 or wire==5 and 10 or wire==8 and 12)
+					local ndata = self.lnwires[errend and 1 or 2][wire]
+					local nwire = ndata
+
+					if istable(ndata) then
+						local dir = data.NW.GetVar(ndata[3] and "RightDir" or "LeftDir",false)
+						nwire = Either(dir,ndata[1],ndata[2])
+					end
 					
 					if nwire then
-						return LoopSavedCalcWheelData(wire,self,data,polepos,polelen,endpos,nwire,simplepos)
+						return nwire
 					else
 						return {error = 1,wire = wire,endpos = errend}
 					end
 				end
-			end,
-			GetWiresCount = function(self) return 12 end,
-			GetWireByConnectable = function(self,connectable)
-				return
-					connectable==1 and 1 or
-					connectable==2 and 2 or
-					connectable==3 and 3 or
-					connectable==4 and 4 or
-					connectable==5 and 7 or
-					connectable==6 and 8,
-					connectable==3 or connectable==4 or connectable==5 or connectable==6
-			end,
-			GetConnectableByWire = function(self,wire,endpos)
-				return
-					wire==1 and !endpos and 1 or
-					wire==2 and !endpos and 2 or
-					wire==3 and endpos and 3 or
-					wire==4 and endpos and 4 or
-					wire==7 and endpos and 5 or
-					wire==8 and endpos and 6
 			end,
 			GetWiresToUpdateVoltage = function(self,connectable)
 				return
@@ -764,6 +725,10 @@ Trolleybus_System.ContactNetwork.Types = {
 			lsusp = {
 				Vector(4.79,14.06,1.66),Vector(20.32,15.53,1.66),Vector(4.76,-13.11,1.66),Vector(20.31,-14.59,1.67)
 			},
+			lnwires = {
+				{nil,nil,1,5,6,2,1,2},
+				{{nil,3,7},{nil,6,8},nil,nil,4,5,nil,nil},
+			},
 			ConnectablePositions = {
 				{
 					GetPosition = function(self,data) return LocalToWorld(self.ldata[1],angle_zero,data.Pos,data.Ang) end,
@@ -807,6 +772,16 @@ Trolleybus_System.ContactNetwork.Types = {
 				},
 			},
 			Properties = {},
+			Wires = {
+				{Start = function(self,data) return self.ldata[8],true end,End = 2},
+				{Start = function(self,data) return self.ldata[7],true end,End = 1},
+				{Start = 6,End = function(self,data) return self.ldata[8],true end},
+				{Start = 5,End = function(self,data) return self.ldata[10],true end},
+				{Start = function(self,data) return self.ldata[10],true end,End = function(self,data) return self.ldata[9],true end},
+				{Start = function(self,data) return self.ldata[9],true end,End = function(self,data) return self.ldata[7],true end},
+				{Start = 4,End = function(self,data) return self.ldata[8],true end},
+				{Start = 3,End = function(self,data) return self.ldata[7],true end},
+			},
 			Initialize = function(self,data,pos,ang)
 				data.Pos = pos
 				data.Ang = ang
@@ -828,13 +803,7 @@ Trolleybus_System.ContactNetwork.Types = {
 			GetPosition = function(self,data) return data.Pos end,
 			Rotate = function(self,data,ang) data.Ang = ang end,
 			GetAngles = function(self,data) return data.Ang end,
-			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,simplepos)
-				local start = self.ldata[wire==1 and 8 or wire==2 and 7 or wire==3 and 6 or wire==4 and 5 or wire==5 and 10 or wire==6 and 9 or wire==7 and 4 or wire==8 and 3]
-				local endp = self.ldata[wire==1 and 2 or wire==2 and 1 or (wire==3 or wire==7) and 8 or wire==4 and 10 or wire==5 and 9 or (wire==6 or wire==8) and 7]
-
-				start = LocalToWorld(start,angle_zero,data.Pos,data.Ang)
-				endp = LocalToWorld(endp,angle_zero,data.Pos,data.Ang)
-
+			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,start,endp,simplepos)
 				local errend,pos,ang = WheelPosOnLine(start,endp,polepos,polelen,endpos)
 
 				if simplepos then
@@ -843,39 +812,19 @@ Trolleybus_System.ContactNetwork.Types = {
 					if pos then return {pos = pos,ang = ang,wire = wire} end
 					if errend==nil then return end
 
-					local rand = math.random(1,3)
+					local ndata = self.lnwires[errend and 1 or 2][wire]
+					local nwire = ndata
 
-					local nwire = errend and
-						((wire==3 or wire==7) and 1 or wire==4 and 5 or wire==5 and 6 or (wire==6 or wire==8) and 2)
-						or !errend and
-						(wire==1 and (rand==1 and 3 or rand==2 and 7 or nil) or wire==2 and (rand==1 and 6 or rand==2 and 8 or nil) or wire==6 and 5 or wire==5 and 4)
+					if istable(ndata) then
+						nwire = ndata[math.random(#ndata)]
+					end
 					
 					if nwire then
-						return LoopSavedCalcWheelData(wire,self,data,polepos,polelen,endpos,nwire,simplepos)
+						return nwire
 					else
 						return {error = 1,wire = wire,endpos = errend}
 					end
 				end
-			end,
-			GetWiresCount = function(self) return 8 end,
-			GetWireByConnectable = function(self,connectable)
-				return
-					connectable==1 and 2 or
-					connectable==2 and 1 or
-					connectable==3 and 8 or
-					connectable==4 and 7 or
-					connectable==5 and 4 or
-					connectable==6 and 3,
-					connectable==1 or connectable==2
-			end,
-			GetConnectableByWire = function(self,wire,endpos)
-				return
-					wire==1 and endpos and 2 or
-					wire==2 and endpos and 1 or
-					wire==3 and !endpos and 6 or
-					wire==4 and !endpos and 5 or
-					wire==7 and !endpos and 4 or
-					wire==8 and !endpos and 3
 			end,
 			GetWiresToUpdateVoltage = function(self,connectable)
 				return
@@ -947,6 +896,9 @@ Trolleybus_System.ContactNetwork.Types = {
 				},
 			},
 			Properties = {},
+			Wires = {
+				{Start = 1,End = 2},
+			},
 			Initialize = function(self,data,pos,ang)
 				data.Pos = pos
 				data.Ang = ang
@@ -963,10 +915,7 @@ Trolleybus_System.ContactNetwork.Types = {
 			end,
 			GetPosition = function(self,data) return data.Pos end,
 			GetAngles = function(self,data) return data.Ang end,
-			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,simplepos)
-				local start = data.Pos
-				local endp = LocalToWorld(self.ldata[1],angle_zero,data.Pos,data.Ang)
-
+			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,start,endp,simplepos)
 				local errend,pos,ang = WheelPosOnLine(start,endp,polepos,polelen,endpos)
 
 				if simplepos then
@@ -977,13 +926,6 @@ Trolleybus_System.ContactNetwork.Types = {
 					
 					return {error = 1,wire = wire,endpos = errend}
 				end
-			end,
-			GetWiresCount = function(self) return 1 end,
-			GetWireByConnectable = function(self,connectable)
-				return 1,connectable==2
-			end,
-			GetConnectableByWire = function(self,wire,endpos)
-				return endpos and 2 or 1
 			end,
 			GetWiresToUpdateVoltage = function(self,connectable)
 				return {}
@@ -1016,6 +958,9 @@ Trolleybus_System.ContactNetwork.Types = {
 				},
 			},
 			Properties = {},
+			Wires = {
+				{Start = 1,End = 2},
+			},
 			Initialize = function(self,data,pos,ang)
 				data.Pos = pos
 				data.Ang = ang
@@ -1034,10 +979,7 @@ Trolleybus_System.ContactNetwork.Types = {
 			GetPosition = function(self,data) return data.Pos end,
 			Rotate = function(self,data,ang) data.Ang = ang end,
 			GetAngles = function(self,data) return data.Ang end,
-			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,simplepos)
-				local start = data.Pos
-				local endp = LocalToWorld(self.ldata,angle_zero,data.Pos,data.Ang)
-
+			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,start,endp,simplepos)
 				local errend,pos,ang = WheelPosOnLine(start,endp,polepos,polelen,endpos)
 
 				if simplepos then
@@ -1048,13 +990,6 @@ Trolleybus_System.ContactNetwork.Types = {
 					
 					return {error = 1,wire = wire,endpos = errend}
 				end
-			end,
-			GetWiresCount = function(self) return 1 end,
-			GetWireByConnectable = function(self,connectable)
-				return 1,connectable==2
-			end,
-			GetConnectableByWire = function(self,wire,endpos)
-				return endpos and 2 or 1
 			end,
 			GetWiresToUpdateVoltage = function(self,connectable)
 				return {}
@@ -1171,6 +1106,10 @@ Trolleybus_System.ContactNetwork.Types = {
 					end,
 				},
 			},
+			Wires = {
+				{Start = 1,End = 2},
+				{Start = 3,End = 4},
+			},
 			Initialize = function(self,data,pos,ang)
 				data.Pos = pos
 				data.Ang = ang
@@ -1203,7 +1142,7 @@ Trolleybus_System.ContactNetwork.Types = {
 				self:updateCurve(data)
 			end,
 			GetAngles = function(self,data) return data.Ang end,
-			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,simplepos)
+			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,start,endp,simplepos)
 				local dt = data.WiresData[wire]
 				local errend,pos,ang = WheelPosAngOnCurve(dt.Center,dt.Radius,true,data.Angle,dt.Start,dt.StartAng,polepos,polelen,endpos,simplepos)
 
@@ -1216,15 +1155,6 @@ Trolleybus_System.ContactNetwork.Types = {
 						return {pos = pos,ang = ang,wire = wire}
 					end
 				end
-			end,
-			GetWiresCount = function(self) return 2 end,
-			GetWireByConnectable = function(self,connectable)
-				return
-					(connectable==1 or connectable==2) and 1 or 2,
-					connectable==2 or connectable==4
-			end,
-			GetConnectableByWire = function(self,wire,endpos)
-				return wire==1 and (endpos and 2 or 1) or (endpos and 4 or 3)
 			end,
 			GetWiresToUpdateVoltage = function(self,connectable)
 				return {(connectable==1 or connectable==2) and 1 or 2}
@@ -1339,6 +1269,14 @@ Trolleybus_System.ContactNetwork.Types = {
 					end,
 				},
 			},
+			Wires = {
+				{Start = 1,End = function(self,data) return data.WiresData[1].Start end},
+				{Start = 3,End = function(self,data) return data.WiresData[2].Start end},
+				{Start = function(self,data) return data.WiresData[1].Start end,End = function(self,data) return data.WiresData[1].End end},
+				{Start = function(self,data) return data.WiresData[2].Start end,End = function(self,data) return data.WiresData[2].End end},
+				{Start = function(self,data) return data.WiresData[1].End end,End = 2},
+				{Start = function(self,data) return data.WiresData[2].End end,End = 4},
+			},
 			Initialize = function(self,data,pos,ang)
 				data.Pos = pos
 				data.Ang = ang
@@ -1383,7 +1321,7 @@ Trolleybus_System.ContactNetwork.Types = {
 				self:updateCurve(data)
 			end,
 			GetAngles = function(self,data) return data.Ang end,
-			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,simplepos,_loop)
+			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,start,endp,simplepos)
 				if wire==3 or wire==4 then
 					local dt = data.WiresData[wire==3 and 1 or 2]
 					local errend,pos,ang = WheelPosAngOnCurve(dt.Center,dt.Radius,true,data.Angle,dt.Start,dt.StartAng,polepos,polelen,endpos,simplepos)
@@ -1392,11 +1330,7 @@ Trolleybus_System.ContactNetwork.Types = {
 						return errend==nil and pos and {pos = pos,ang = ang} or nil
 					else
 						if errend!=nil then
-							local nwire = 
-							errend and (wire==3 and 5 or 6) or
-							!errend and (wire==3 and 1 or 2)
-						
-							return LoopSavedCalcWheelData(wire,self,data,polepos,polelen,endpos,nwire,simplepos)
+							return errend and (wire==3 and 5 or 6) or (wire==3 and 1 or 2)
 						end
 
 						if pos then
@@ -1404,13 +1338,6 @@ Trolleybus_System.ContactNetwork.Types = {
 						end
 					end
 				else
-					local isleft = wire==1 or wire==5
-					local isend = wire==5 or wire==6
-
-					local dt = data.WiresData[isleft and 1 or 2]
-					local start = isend and dt.End or dt.Start2
-					local endp = isend and dt.End2 or dt.Start
-
 					local errend,pos,ang = WheelPosOnLine(start,endp,polepos,polelen,endpos)
 					if !pos then
 						if !simplepos then
@@ -1418,9 +1345,7 @@ Trolleybus_System.ContactNetwork.Types = {
 							errend and (wire==1 and 3 or wire==2 and 4) or
 							!errend and (wire==5 and 3 or wire==6 and 4)
 
-							if nwire then
-								return LoopSavedCalcWheelData(wire,self,data,polepos,polelen,endpos,nwire,simplepos)
-							end
+							if nwire then return nwire end
 						end
 
 						return errend!=nil and {error = 1,wire = wire,endpos = errend} or nil
@@ -1428,22 +1353,6 @@ Trolleybus_System.ContactNetwork.Types = {
 
 					return {pos = pos,ang = ang,wire = wire}
 				end
-			end,
-			GetWiresCount = function(self) return 6 end,
-			GetWireByConnectable = function(self,connectable)
-				return
-					connectable==1 and 1 or
-					connectable==2 and 5 or
-					connectable==3 and 2 or
-					connectable==4 and 6,
-					connectable==2 or connectable==4
-			end,
-			GetConnectableByWire = function(self,wire,endpos)
-				return
-					wire==1 and !endpos and 1 or
-					wire==2 and !endpos and 3 or
-					wire==5 and endpos and 2 or
-					wire==6 and endpos and 4
 			end,
 			GetWiresToUpdateVoltage = function(self,connectable)
 				return
@@ -1507,6 +1416,12 @@ Trolleybus_System.ContactNetwork.Types = {
 				},
 			},
 			Properties = {},
+			Wires = {
+				{Start = 1,End = 3},
+				{Start = 2,End = 4},
+				{Start = 5,End = 7},
+				{Start = 6,End = 8},
+			},
 			Initialize = function(self,data,pos,ang)
 				data.Pos = pos
 				data.Ang = ang
@@ -1525,13 +1440,7 @@ Trolleybus_System.ContactNetwork.Types = {
 			GetPosition = function(self,data) return data.Pos end,
 			Rotate = function(self,data,ang) data.Ang = ang end,
 			GetAngles = function(self,data) return data.Ang end,
-			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,simplepos)
-				local start = self.ldata[wire==1 and 1 or wire==2 and 2 or wire==3 and 5 or wire==4 and 6]
-				local endp = self.ldata[wire==1 and 3 or wire==2 and 4 or wire==3 and 7 or wire==4 and 8]
-
-				start = LocalToWorld(start,angle_zero,data.Pos,data.Ang)
-				endp = LocalToWorld(endp,angle_zero,data.Pos,data.Ang)
-
+			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,start,endp,simplepos)
 				local errend,pos,ang = WheelPosOnLine(start,endp,polepos,polelen,endpos)
 
 				if simplepos then
@@ -1542,22 +1451,6 @@ Trolleybus_System.ContactNetwork.Types = {
 					
 					return {error = 1,wire = wire,endpos = errend}
 				end
-			end,
-			GetWiresCount = function(self) return 4 end,
-			GetWireByConnectable = function(self,connectable)
-				return
-					(connectable==1 or connectable==3) and 1 or
-					(connectable==2 or connectable==4) and 2 or
-					(connectable==5 or connectable==7) and 3 or
-					(connectable==6 or connectable==8) and 4,
-					connectable==3 or connectable==4 or connectable==7 or connectable==8
-			end,
-			GetConnectableByWire = function(self,wire,endpos)
-				return
-					wire==1 and (endpos and 3 or 1) or
-					wire==2 and (endpos and 4 or 2) or
-					wire==3 and (endpos and 7 or 5) or
-					wire==4 and (endpos and 8 or 6)
 			end,
 			GetWiresToUpdateVoltage = function(self,connectable)
 				return {}
@@ -1623,6 +1516,12 @@ Trolleybus_System.ContactNetwork.Types = {
 				},
 			},
 			Properties = {},
+			Wires = {
+				{Start = 1,End = 3},
+				{Start = 2,End = 4},
+				{Start = 5,End = 7},
+				{Start = 6,End = 8},
+			},
 			Initialize = function(self,data,pos,ang)
 				data.Pos = pos
 				data.Ang = ang
@@ -1641,13 +1540,7 @@ Trolleybus_System.ContactNetwork.Types = {
 			GetPosition = function(self,data) return data.Pos end,
 			Rotate = function(self,data,ang) data.Ang = ang end,
 			GetAngles = function(self,data) return data.Ang end,
-			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,simplepos)
-				local start = self.ldata[wire==1 and 1 or wire==2 and 2 or wire==3 and 5 or wire==4 and 6]
-				local endp = self.ldata[wire==1 and 3 or wire==2 and 4 or wire==3 and 7 or wire==4 and 8]
-
-				start = LocalToWorld(start,angle_zero,data.Pos,data.Ang)
-				endp = LocalToWorld(endp,angle_zero,data.Pos,data.Ang)
-
+			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,start,endp,simplepos)
 				local errend,pos,ang = WheelPosOnLine(start,endp,polepos,polelen,endpos)
 
 				if simplepos then
@@ -1658,22 +1551,6 @@ Trolleybus_System.ContactNetwork.Types = {
 					
 					return {error = 1,wire = wire,endpos = errend}
 				end
-			end,
-			GetWiresCount = function(self) return 4 end,
-			GetWireByConnectable = function(self,connectable)
-				return
-					(connectable==1 or connectable==3) and 1 or
-					(connectable==2 or connectable==4) and 2 or
-					(connectable==5 or connectable==7) and 3 or
-					(connectable==6 or connectable==8) and 4,
-					connectable==3 or connectable==4 or connectable==7 or connectable==8
-			end,
-			GetConnectableByWire = function(self,wire,endpos)
-				return
-					wire==1 and (endpos and 3 or 1) or
-					wire==2 and (endpos and 4 or 2) or
-					wire==3 and (endpos and 7 or 5) or
-					wire==4 and (endpos and 8 or 6)
 			end,
 			GetWiresToUpdateVoltage = function(self,connectable)
 				return {}
@@ -1739,6 +1616,12 @@ Trolleybus_System.ContactNetwork.Types = {
 				},
 			},
 			Properties = {},
+			Wires = {
+				{Start = 1,End = 3},
+				{Start = 2,End = 4},
+				{Start = 5,End = 7},
+				{Start = 6,End = 8},
+			},
 			Initialize = function(self,data,pos,ang)
 				data.Pos = pos
 				data.Ang = ang
@@ -1757,13 +1640,7 @@ Trolleybus_System.ContactNetwork.Types = {
 			GetPosition = function(self,data) return data.Pos end,
 			Rotate = function(self,data,ang) data.Ang = ang end,
 			GetAngles = function(self,data) return data.Ang end,
-			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,simplepos)
-				local start = self.ldata[wire==1 and 1 or wire==2 and 2 or wire==3 and 5 or wire==4 and 6]
-				local endp = self.ldata[wire==1 and 3 or wire==2 and 4 or wire==3 and 7 or wire==4 and 8]
-
-				start = LocalToWorld(start,angle_zero,data.Pos,data.Ang)
-				endp = LocalToWorld(endp,angle_zero,data.Pos,data.Ang)
-
+			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,start,endp,simplepos)
 				local errend,pos,ang = WheelPosOnLine(start,endp,polepos,polelen,endpos)
 
 				if simplepos then
@@ -1774,22 +1651,6 @@ Trolleybus_System.ContactNetwork.Types = {
 					
 					return {error = 1,wire = wire,endpos = errend}
 				end
-			end,
-			GetWiresCount = function(self) return 4 end,
-			GetWireByConnectable = function(self,connectable)
-				return
-					(connectable==1 or connectable==3) and 1 or
-					(connectable==2 or connectable==4) and 2 or
-					(connectable==5 or connectable==7) and 3 or
-					(connectable==6 or connectable==8) and 4,
-					connectable==3 or connectable==4 or connectable==7 or connectable==8
-			end,
-			GetConnectableByWire = function(self,wire,endpos)
-				return
-					wire==1 and (endpos and 3 or 1) or
-					wire==2 and (endpos and 4 or 2) or
-					wire==3 and (endpos and 7 or 5) or
-					wire==4 and (endpos and 8 or 6)
 			end,
 			GetWiresToUpdateVoltage = function(self,connectable)
 				return {(connectable==5 or connectable==7) and 3 or (connectable==6 or connectable==8) and 4 or nil}
@@ -1844,6 +1705,9 @@ Trolleybus_System.ContactNetwork.Types = {
 				},
 			},
 			Properties = {},
+			Wires = {
+				{Start = 3,End = 4},
+			},
 			Initialize = function(self,data,pos,ang)
 				data.Pos = pos
 				data.Ang = ang
@@ -1862,10 +1726,7 @@ Trolleybus_System.ContactNetwork.Types = {
 			GetPosition = function(self,data) return data.Pos end,
 			Rotate = function(self,data,ang) data.Ang = ang end,
 			GetAngles = function(self,data) return data.Ang end,
-			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,simplepos)
-				start = LocalToWorld(self.ldata[3],angle_zero,data.Pos,data.Ang)
-				endp = LocalToWorld(self.ldata[4],angle_zero,data.Pos,data.Ang)
-
+			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,start,endp,simplepos)
 				local errend,pos,ang = WheelPosOnLine(start,endp,polepos,polelen,endpos)
 
 				if simplepos then
@@ -1876,13 +1737,6 @@ Trolleybus_System.ContactNetwork.Types = {
 					
 					return {error = 1,wire = wire,endpos = errend}
 				end
-			end,
-			GetWiresCount = function(self) return 1 end,
-			GetWireByConnectable = function(self,connectable)
-				return (connectable==3 or connectable==4) and 1,connectable==4
-			end,
-			GetConnectableByWire = function(self,wire,endpos)
-				return endpos and 4 or 3
 			end,
 			GetWiresToUpdateVoltage = function(self,connectable)
 				return {}
@@ -1957,6 +1811,14 @@ Trolleybus_System.ContactNetwork.Types = {
 				},
 			},
 			Properties = {},
+			Wires = {
+				{Start = 1,End = 3},
+				{Start = 2,End = 4},
+				{Start = 5,End = 7},
+				{Start = 6,End = 8},
+				{Start = 9,End = 11},
+				{Start = 10,End = 12},
+			},
 			Initialize = function(self,data,pos,ang)
 				data.Pos = pos
 				data.Ang = ang
@@ -1975,13 +1837,7 @@ Trolleybus_System.ContactNetwork.Types = {
 			GetPosition = function(self,data) return data.Pos end,
 			Rotate = function(self,data,ang) data.Ang = ang end,
 			GetAngles = function(self,data) return data.Ang end,
-			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,simplepos)
-				local start = self.ldata[wire==1 and 1 or wire==2 and 2 or wire==3 and 5 or wire==4 and 6 or wire==5 and 9 or wire==6 and 10]
-				local endp = self.ldata[wire==1 and 3 or wire==2 and 4 or wire==3 and 7 or wire==4 and 8 or wire==5 and 11 or wire==6 and 12]
-
-				start = LocalToWorld(start,angle_zero,data.Pos,data.Ang)
-				endp = LocalToWorld(endp,angle_zero,data.Pos,data.Ang)
-
+			CalculateWheelData = function(self,data,polepos,polelen,endpos,wire,start,endp,simplepos)
 				local errend,pos,ang = WheelPosOnLine(start,endp,polepos,polelen,endpos)
 
 				if simplepos then
@@ -1992,26 +1848,6 @@ Trolleybus_System.ContactNetwork.Types = {
 					
 					return {error = 1,wire = wire,endpos = errend}
 				end
-			end,
-			GetWiresCount = function(self) return 6 end,
-			GetWireByConnectable = function(self,connectable)
-				return
-					(connectable==1 or connectable==3) and 1 or
-					(connectable==2 or connectable==4) and 2 or
-					(connectable==5 or connectable==7) and 3 or
-					(connectable==6 or connectable==8) and 4 or
-					(connectable==9 or connectable==11) and 5 or
-					(connectable==10 or connectable==12) and 6,
-					connectable==3 or connectable==4 or connectable==7 or connectable==8 or connectable==11 or connectable==12
-			end,
-			GetConnectableByWire = function(self,wire,endpos)
-				return
-					wire==1 and (endpos and 3 or 1) or
-					wire==2 and (endpos and 4 or 2) or
-					wire==3 and (endpos and 7 or 5) or
-					wire==4 and (endpos and 8 or 6) or
-					wire==5 and (endpos and 11 or 9) or
-					wire==6 and (endpos and 12 or 10)
 			end,
 			GetWiresToUpdateVoltage = function(self,connectable)
 				return {}
@@ -3064,6 +2900,21 @@ local CONTACT_NETWORK_CONTACT_OBJECT = table.Inherit({
 		self.Class = {Id = 0,Name = "Contact"}
 
 		self.BaseClass.Init(self,Trolleybus_System.ContactNetwork.Types.Contacts[type],pos,ang)
+
+		self.contowire = {}
+		self.wiretocon = {{},{}}
+
+		for k,v in ipairs(self.Cfg.Wires) do
+			if isnumber(v.Start) then
+				self.contowire[v.Start] = {k,false}
+				self.wiretocon[1][k] = v.Start
+			end
+
+			if isnumber(v.End) then
+				self.contowire[v.End] = {k,true}
+				self.wiretocon[2][k] = v.End
+			end
+		end
 	end,
 	GetTransmitData = function(self)
 		return table.Merge(self.BaseClass.GetTransmitData(self),{
@@ -3088,13 +2939,26 @@ local CONTACT_NETWORK_CONTACT_OBJECT = table.Inherit({
 		return self.Cfg.MainContact
 	end,
 	CalculateWheelData = function(self,polepos,polelen,endpos,wire,simplepos)
-		return self.Cfg:CalculateWheelData(self.Data,polepos,polelen,endpos,wire,simplepos)
+		local loop = {}
+
+		while !loop[wire] do
+			loop[wire] = true
+
+			local data = self.Cfg:CalculateWheelData(self.Data,polepos,polelen,endpos,wire,self:GetWirePos(wire,false),self:GetWirePos(wire,true),simplepos)
+			if !isnumber(data) then return data end
+
+			wire = data
+		end
 	end,
 	GetWireByConnectable = function(self,connectable)
-		return self.Cfg:GetWireByConnectable(connectable)
+		local wdata = self.contowire[connectable]
+
+		if wdata then
+			return wdata[1],wdata[2]
+		end
 	end,
 	GetConnectableByWire = function(self,wire,endpos)
-		return self.Cfg:GetConnectableByWire(wire,endpos)
+		return self.wiretocon[endpos and 2 or 1][wire]
 	end,
 	GetWiresToUpdateVoltage = function(self,connectable)
 		return self.Cfg:GetWiresToUpdateVoltage(connectable)
@@ -3121,8 +2985,23 @@ local CONTACT_NETWORK_CONTACT_OBJECT = table.Inherit({
 	LinkWireToVoltageSource = function(self,wire,voltsrc)
 		self:SetNWVar("voltsrc"..wire,voltsrc and Trolleybus_System.ContactNetwork.GetObjectName(voltsrc) or nil)
 	end,
+	GetWirePos = function(self,wire,endpos)
+		local pos = self.Cfg.Wires[wire][endpos and "End" or "Start"]
+		local loc = true
+
+		if pos==true then
+			pos,loc = self.Cfg:GetWirePos(self.Data,wire,endpos)
+		elseif isfunction(pos) then
+			pos,loc = pos(self.Cfg,self.Data)
+		elseif isnumber(pos) then
+			pos,loc = self:GetConnectablePos(pos),false
+		end
+		
+		if loc then pos = LocalToWorld(pos,angle_zero,self:GetPos(),self:GetAngles()) end
+		return pos
+	end,
 	GetWiresCount = function(self)
-		return self.Cfg:GetWiresCount()
+		return #self.Cfg.Wires
 	end,
 	AmperageUpdate = function(self,wire,amperage)
 		if self.Cfg.AmperageUpdate then

--- a/lua/trolleybus_system/contactnetwork.lua
+++ b/lua/trolleybus_system/contactnetwork.lua
@@ -3207,6 +3207,8 @@ function Trolleybus_System.ContactNetwork.CreateFromTransmitData(data)
 	elseif data.Class==1 then
 		object = Trolleybus_System.ContactNetwork.CreateSuspensionAndOther(data.Type,Vector(),Angle())
 	end
+
+	if !object then return end
 	
 	for k,v in pairs(data.Properties) do
 		object:SetProperty(k,v)
@@ -3220,11 +3222,13 @@ end
 function Trolleybus_System.ContactNetwork.AddObject(name,data)
 	Trolleybus_System.ContactNetwork.RemoveObject(name)
 
-	local objtype = Trolleybus_System.ContactNetwork.Objects[data.Class==0 and "Contacts" or data.Class==1 and "SuspensionAndOther"]
-	objtype[name] = Trolleybus_System.ContactNetwork.CreateFromTransmitData(data)
-	objtype[name]:InitializeNetworkDataTable(name)
+	local object = Trolleybus_System.ContactNetwork.CreateFromTransmitData(data)
+	if !object then return end
 
-	return objtype[name]
+	Trolleybus_System.ContactNetwork.Objects[data.Class==0 and "Contacts" or data.Class==1 and "SuspensionAndOther"][name] = object
+	object:InitializeNetworkDataTable(name)
+
+	return object
 end
 
 function Trolleybus_System.ContactNetwork.NewObject(class,type,pos,ang)

--- a/lua/trolleybus_system/shared.lua
+++ b/lua/trolleybus_system/shared.lua
@@ -14,7 +14,7 @@ Trolleybus_System.TracksPowerDisabled = Trolleybus_System.TracksPowerDisabled or
 Trolleybus_System.MaxTrolleybusPolesUpAng = -50
 Trolleybus_System.UnitsPerMeter = 37.777
 
-Trolleybus_System.VERSION = "Beta 1.0"
+Trolleybus_System.VERSION = "Beta 1.1"
 
 Trolleybus_System.DefaultMaps = {
 	gm_sumy_reborn = true,

--- a/lua/trolleybus_system/sv_contactnetwork.lua
+++ b/lua/trolleybus_system/sv_contactnetwork.lua
@@ -43,10 +43,18 @@ function Trolleybus_System.ContactNetwork.Load(ply)
 
 		for k,v in pairs(network) do
 			objs[k] = Trolleybus_System.ContactNetwork.AddObject(k,v)
+
+			if !objs[k] then
+				print("Trolleybus System: Failed to load contact network object '"..k.."'")
+			end
 		end
 
 		for k,v in pairs(network) do
+			if !objs[k] then continue end
+
 			for k2,v2 in pairs(v.Connections) do
+				if !objs[v2[1]] then continue end
+
 				objs[k]:ConnectConnectableTo(k2,objs[v2[1]],v2[2])
 			end
 		end

--- a/lua/trolleybus_system/sv_contactnetwork.lua
+++ b/lua/trolleybus_system/sv_contactnetwork.lua
@@ -135,15 +135,15 @@ function Trolleybus_System.ContactNetwork.UpdateWiresVoltageLinks()
 
 	for k,v in pairs(Trolleybus_System.ContactNetwork.Objects.Contacts) do
 		if v.Cfg.VoltageSource then
-			loop[v] = {[1] = true,[2] = true}
-
 			for i=1,2 do
-				local positive = i==1
-				local connections = {unpack(v:GetOtherConnections(i,true))}
+				local positive = i%2==1
+				local connections = v:GetOtherConnections(i,true)
 
 				while #connections>0 do
 					local connection = table.remove(connections,1)
 					local obj,id = connection[1],connection[2]
+					
+					if obj.Cfg.VoltageSource then continue end
 
 					for k2,v2 in ipairs(obj:GetWiresToUpdateVoltage(id)) do
 						obj:SetWirePolarity(v2,positive)

--- a/lua/trolleybus_system/tools/trolleybus_cn_editor/cl_init.lua
+++ b/lua/trolleybus_system/tools/trolleybus_cn_editor/cl_init.lua
@@ -1398,6 +1398,8 @@ local function StartCopyObjects(pnl,data)
 
 			for k,v in pairs(data) do
 				local model = Trolleybus_System.ContactNetwork.CreateFromTransmitData(v.Data)
+				if !model then continue end
+
 				table.insert(self.Models,model)
 
 				local p,a = LocalToWorld(v.Pos,v.Ang,pos,ang)

--- a/lua/trolleybus_system/tools/trolleybus_cn_editor/cl_init.lua
+++ b/lua/trolleybus_system/tools/trolleybus_cn_editor/cl_init.lua
@@ -739,24 +739,25 @@ function TOOL:Render()
 	
 	if table.IsEmpty(self:GetSelectedConnectables()) then
 		local name,obj = next(self:GetSelectedObjects())
-		local color = Color(100,200,0)
+		local colorp = Color(150,200,0)
+		local colorn = Color(200,150,0)
+		local colord = Color(200,0,0)
 		
 		if obj and obj.Class.Id==0 and !next(self:GetSelectedObjects(),name) then
 			for i=1,obj:GetWiresCount() do
-				local starti = obj.Cfg.VoltageSource and 1 or obj:GetConnectableByWire(i,false)
-				local endi = obj.Cfg.VoltageSource and 2 or obj:GetConnectableByWire(i,true)
+				local start = obj:GetWirePos(i,false)
+				local endp = obj:GetWirePos(i,true)
 
-				if starti and endi then
+				if start and endp then
 					local voltage,positive = obj:GetWireVoltage(i)
-					local start = obj:GetConnectablePos(starti)
-					local endp = obj:GetConnectablePos(endi)
+					local volt = positive and voltage or -voltage
 
-					self:DrawLine(start,endp,color)
+					render.DrawLine(start,endp,volt>0 and colorp or volt<0 and colorn or colord)
 
 					local voltsrc = obj:GetWireLinkedVoltageSource(i)
 					local voltname = voltsrc and Trolleybus_System.ContactNetwork.GetObjectName(voltsrc) or "-"
 
-					debugoverlay.Text((start+endp)/2,Format("%i. %s%.1f V (source: %s)",i,obj:GetWirePolarity(i) and "+" or "-",positive and voltage or -voltage,voltname),0.1,false)
+					debugoverlay.Text((start+endp)/2,Format("%i. %s%.1f V (src: %s)",i,obj:GetWirePolarity(i) and "+" or "-",volt,voltname),0.1,false)
 				end
 			end
 		end


### PR DESCRIPTION
- Removed old unused commented code.
- Added checks for unknown contact network object types to prevent errors.
- Now wires in contact network objects is not an abstraction. Wires structure changed across all contact objects and its base class. Contact network editor tool also displays each wire and its voltage.
- Trolleybus switch movable contacts now will move corresponding wires in contact network object.